### PR TITLE
Add CPU Usage monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ php artisan stat:mem
 
 The available stat commands are:
 
+- `stat:cpu`
 - `stat:disk`
 - `stat:load`
 - `stat:mem`
@@ -20,7 +21,8 @@ The available stat commands are:
 
 Forge Monitor provides alerting for several monitor types:
 
-- `cpu_load` - CPU Load (%)
+- `cpu_load` - System Load (%)
+- `cpu` - CPU Usage (%)
 - `disk` - Free Disk Space (%)
 - `free_memory` - Free Memory (%)
 - `used_memory` - Used Memory (%)

--- a/app/Console/Commands/CpuStatCommand.php
+++ b/app/Console/Commands/CpuStatCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CpuStatCommand extends AbstractStatCommand
+{
+    use InteractsWithCli;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'stat:cpu {--E|endpoint= : The endpoint to ping.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sample CPU usage.';
+
+    /**
+     * Whether the sample has been taken.
+     *
+     * @var bool
+     */
+    protected $sampleTaken;
+
+    /**
+     * The stat type to look for when running the command.
+     *
+     * @var array|string
+     */
+    protected $statType = ['cpu'];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Don't run when no monitors are configured.
+        if ($this->monitors->isEmpty()) {
+            $this->verboseInfo("No CPU Load monitors configured...");
+
+            return;
+        }
+
+        $this->monitors->each(function ($monitor) {
+            if (!$this->sampleTaken) {
+                $monitor->stat()->sample();
+
+                $this->sampleTaken = true;
+            }
+        })->each(function ($monitor) {
+            $this->verboseInfo("Testing {$monitor->key}...");
+
+            $monitor->stat()->test();
+        });
+    }
+}

--- a/app/CpuUsage.php
+++ b/app/CpuUsage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CpuUsage extends Model
+{
+    /**
+     * The name of the table in which this Model stored.
+     *
+     * @var string
+     */
+    protected $table = 'cpu_usage';
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}

--- a/app/Monitors/Monitor.php
+++ b/app/Monitors/Monitor.php
@@ -3,6 +3,7 @@
 namespace App\Monitors;
 
 use App\Stats\CpuLoad;
+use App\Stats\CpuUsage;
 use App\Stats\DiskSpace;
 use App\Stats\FreeMemory;
 use App\Stats\LoadAvg;
@@ -74,6 +75,7 @@ class Monitor
     public function stat()
     {
         switch ($this->type) {
+            case 'cpu': return new CpuUsage($this);
             case 'disk': return new DiskSpace($this);
             case 'cpu_load': return new LoadAvg($this);
             case 'free_memory': return new FreeMemory($this);

--- a/app/Stats/CpuUsage.php
+++ b/app/Stats/CpuUsage.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Stats;
+
+use App\CpuUsage as CpuUsageModel;
+use App\Monitors\Monitor;
+use Illuminate\Support\Facades\DB;
+
+class CpuUsage extends AbstractStat implements Stat
+{
+    /**
+     * Create a new Stat instance.
+     *
+     * @param  \App\Monitors\Monitor $monitor
+     * @return void
+     */
+    public function __construct(Monitor $monitor)
+    {
+        $this->monitor = $monitor;
+    }
+
+    /**
+     * Sample the stat.
+     *
+     * @return void
+     */
+    public function sample()
+    {
+        /*
+        |--------------------------------------------------------------------------
+        | /proc/stat
+        |--------------------------------------------------------------------------
+        |
+        | /proc/stat is actually the Linux kernel's system statistics pool, where
+        | the kernel writes immediate statistics about its behavior. The first
+        | line of the file has the format
+        | cpuN user nice system idle io_wait irq soft_irq steal guest guest_nice
+        | awk:  $2   $3    $4    $5    $6     $7    $8      $9
+        |
+        | Where user, nice, and so forth are expressed in number of jiffies
+        | (approx 1/100th of a second) spent running processes in those
+        | categories.
+        |
+        | The first line of /proc/stat is an aggregation of all CPU cores, so we
+        | can use the one line as opposed to reading x lines and summing them
+        | ourselves.
+        |
+        | We calculate how much the CPU is idle from the stats
+        | thus we can determine how busy the CPU really is.
+        |
+        | See man 5 proc for more information.
+        |
+        */
+
+        if (is_readable("/proc/stat")) {
+            $cpuIdle = (float) $this->executeCommand("grep 'cpu ' /proc/stat | awk '{idle=($5*100)/($2+$3+$4+$5+$6+$7+$8+$9)} END {print idle}'");
+            $cpuUsage = (float) 100 - $cpuIdle;
+
+            CpuUsageModel::create([
+                'used' => $cpuUsage,
+                'idle' => $cpuIdle,
+            ]);
+        }
+    }
+
+    /**
+     * Test the stat.
+     *
+     * @return bool
+     */
+    public function test()
+    {
+        $op = $this->getOperator();
+
+        $results = DB::select("SELECT
+    CASE WHEN used {$op} ? THEN 'ALERT' ELSE 'OK' END AS currentState,
+    IFNULL(alerts.monitor_state, 'UNKNOWN') AS lastState
+FROM (
+    SELECT * FROM cpu_usage WHERE created_at >= DATETIME('NOW', ?) ORDER BY created_at DESC LIMIT ?
+) _samples
+LEFT JOIN (SELECT * FROM alerts WHERE monitor_id = ? AND monitor_type = ? ORDER BY created_at DESC LIMIT 1) alerts", [
+            $this->monitor->threshold,
+            '-'.($this->monitor->minutes + 1).' minutes',
+            $this->monitor->minutes + 1,
+            $this->monitor->key,
+            $this->monitor->type,
+        ]);
+
+        return $this->testResults($results);
+    }
+
+}

--- a/database/migrations/2022_07_26_183629_create_cpu_usage_table.php
+++ b/database/migrations/2022_07_26_183629_create_cpu_usage_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCpuUsageTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cpu_usage', function (Blueprint $table) {
+            $table->id();
+            $table->float('used', 5, 2);
+            $table->float('idle', 5, 2);
+            $table->timestamps();
+
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cpu_usages');
+    }
+}


### PR DESCRIPTION
On Linux systems, as used by Forge, the load average is a diminishing average calculation based on processes running, ready to run, waiting for IO *and* uninterruptable processes. For this reason, we cannot compute CPU load based on Load Average.

Instead, we should rebrand CPU Load to System Load, and introduce a new type of monitor: CPU Usage.

The proposed monitor uses `/proc/stat` to find the aggregated, kernel-written, CPU statistics for all cores in the system, basically calculates Idle Time as a percentage, and then uses that to derive the opposite value: CPU Usage. (This works intuitively the same way as what Windows OS does in the Task Manager).

Following changes are made:
- Introduce `stat:cpu` command and monitor
- Document `stat:cpu` and rebrand `stat:cpu_load` from "CPU Load" to "System Load"
- Add CpuUsage model and table `cpu_usage`
- Add CPU statistics class to sample and test the statistic