### PR TITLE
[CORE-3062] Report initial state when stats already exist

### DIFF
--- a/app/Stats/AbstractStat.php
+++ b/app/Stats/AbstractStat.php
@@ -50,12 +50,12 @@ abstract class AbstractStat
     {
         $this->totalResults = count($results);
 
-        if ($this->totalResults === 1) {
-            $this->reportInitialState($results[0]);
-        }
-
-        // Not enough data to check.
+        // Not enough data to check streak, but report initial state if needed.
         if ($this->totalResults < $this->monitor->minutes) {
+            if ($this->totalResults > 0 && $results[0]->lastState === self::UNKNOWN) {
+                $this->reportInitialState($results[0]);
+            }
+
             return false;
         }
 


### PR DESCRIPTION
`reportInitialState()` was only firing for newly created monitors where no metric data existed. This change ensures the state is reported for newly created monitors, where a monitor for the same type already exists, or where a monitor was deleted and then re-added.